### PR TITLE
fix: remove arlac77/koa-github-hook-handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
       "arlac77/entitlement-provider",
       "arlac77/hook-ci-frontend",
       "arlac77/keytar-auth-provider",
-      "arlac77/koa-github-hook-handler",
       "arlac77/kv-reader",
       "arlac77/loglevel-mixin",
       "arlac77/model",


### PR DESCRIPTION
fix: remove arlac77/koa-github-hook-handler